### PR TITLE
Bump the Version to the Next Major Version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.10.0"
 org = "ballerinax"
 name = "hubspot.crm.import"
-version = "1.0.0"
+version = "3.0.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["hubspot","crm","imports"]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -262,6 +262,9 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "os", moduleName = "os"}
+]
 
 [[package]]
 org = "ballerina"
@@ -320,12 +323,13 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.import"
-version = "1.0.0"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"},
 	{org = "ballerinai", name = "observe"}

--- a/examples/handle-import/main.bal
+++ b/examples/handle-import/main.bal
@@ -19,14 +19,14 @@
 
 import ballerina/io;
 import ballerina/oauth2;
-import ballerinax/hubspot.crm.'import as crmImport;
+import ballerinax/hubspot.crm.'import as crmimport;
 
 // OAuth 2.0 Credentials
 configurable string clientId = ?;
 configurable string clientSecret = ?;
 configurable string refreshToken = ?;
 
-crmImport:OAuth2RefreshTokenGrantConfig auth = {
+crmimport:OAuth2RefreshTokenGrantConfig auth = {
     clientId,
     clientSecret,
     refreshToken,
@@ -34,7 +34,7 @@ crmImport:OAuth2RefreshTokenGrantConfig auth = {
 };
 
 // Initialize the client
-final crmImport:Client importClient = check new ({auth});
+final crmimport:Client hubspotImport = check new ({auth});
 
 public function main() returns error? {
     // Create an import request body
@@ -45,7 +45,7 @@ public function main() returns error? {
     byte[] bytes = check io:fileReadBytes(filePath);
 
     // Request body
-    crmImport:body requestBody = {
+    crmimport:body requestBody = {
         files: {
             fileContent: bytes,
             fileName: "contact_import_file.csv"
@@ -55,7 +55,7 @@ public function main() returns error? {
 
     // Create an import
     io:println("Creating an import...");
-    crmImport:PublicImportResponse response = check importClient->/.post(payload = requestBody);
+    crmimport:PublicImportResponse response = check hubspotImport->/.post(payload = requestBody);
     io:println("The import is in the state : " + response.state);
 
     // Check if the import is successful
@@ -68,7 +68,7 @@ public function main() returns error? {
 
     // Fetching the status of this import
     io:println("\nFetching the status of the import " + responseId.toString() + "...");
-    crmImport:PublicImportResponse|error statusResponse = importClient->/[responseId].get();
+    crmimport:PublicImportResponse|error statusResponse = hubspotImport->/[responseId].get();
     if statusResponse is error {
         io:println("Failed to fetch the status of the import");
     } else {
@@ -78,7 +78,7 @@ public function main() returns error? {
 
     // Cancel the import
     io:println("\nCanceling the import " + responseId.toString() + "...");
-    crmImport:ActionResponse|error cancelResponse = importClient->/[responseId]/cancel.post();
+    crmimport:ActionResponse|error cancelResponse = hubspotImport->/[responseId]/cancel.post();
 
     if cancelResponse is error {
         io:println("Failed to cancel the import");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.0.0-SNAPSHOT
+version=3.0.0-SNAPSHOT
 
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.2.4


### PR DESCRIPTION
## Purpose

This will bump the version to `3.0.0`, which is the next major version. This connector has already been released the `2.3.1` version, therefore going with the `3.0.0` version

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
