### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.import/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.import/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.import.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.import/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.import.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.import)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.import.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.import)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector audit. Refs ballerina-platform/ballerina-library#8823.

- Fix encoding in the GitHub Issues badge URL in the root `README.md` so the badge link resolves to the correct GitHub label (`module%hubspot.crm.import` -> `module%2Fhubspot.crm.import`).

The other systemic README fixes from the audit (replacing `Hubspot` with `HubSpot`, fixing the `ave` typo, removing a duplicated `Ballerina` from the title) did not apply to this repo:

- No standalone brand-name `Hubspot` occurrences in prose; the only matches are inside image alt-text, which the audit guidance leaves as-is.
- No standalone `ave` typo present.
- The title is already in the canonical `# Ballerina HubSpot CRM Import connector` form.

## Examples

N/A -- documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility